### PR TITLE
Frozen rows/cols support

### DIFF
--- a/src/SimpleXLSXGen.php
+++ b/src/SimpleXLSXGen.php
@@ -1062,7 +1062,7 @@ class SimpleXLSXGen
         return $absolute . $c . $absolute . ($y+1);
     }
 
-    public function setFrozen($cell)
+    public function freezePanes($cell)
     {
         $this->sheets[$this->curSheet]['frozen'] = $cell;
         return $this;


### PR DESCRIPTION
Added setFrozen method to freeze rows and columns from top-left corner up to, but not including, the row and column of the passed parameter. For example:
$xlsx->setFrozen('B3');
freezes first column (A) and first and second rows (1 and 2)