### PR TITLE
Update SimpleXLSXGen.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.11 (2024-02-07)
+* hyperlinks to local files
+* num2name static now
+
 ## 1.4.10 (2023-12-31)
 * added SimpleXLSXGen::create($title = null) to create empty book with title
 * added SimpleXLSXGen::save to save xlsx in current folder as {$title}.xslx or {$curdate}.xlsx

--- a/README.md
+++ b/README.md
@@ -138,6 +138,18 @@ $xlsx = SimpleXLSX::create('My books');
 $xlsx->addSheet( $books );
 $xlsx->save(); // ./My books.xlsx
 
+// Hyperlinks
+$xlsx = SimpleXLSX::fromArray([
+    ['internal link', '<a href="\'My books 2\'!A1">Go to second sheet</a>'],
+    ['http', 'https://example.com/'], // autodetect
+    ['http + hash', 'https://en.wikipedia.org/wiki/Office_Open_XML#References'], // autodetect
+    ['external anchor', '<a href="https://en.wikipedia.org/wiki/Office_Open_XML#References">Open XML</a>'],
+    ['relative link', '<a href="books.xlsx">books</a>'],
+    ['relative link + cell addr', '<a href="..\books.xlsx#\'Sheet 2\'!A1">link to second sheet in other book</a>'],
+    ['mailto', 'info@example.com'], // autodetect
+    ['mailto 2', '<a href="mailto:info@example.com">Please email me</a>'],
+])->addSheet([['Second sheet']], 'My books 2')->saveAs('hyperlinks.xlsx');
+
 // Autofilter
 $xlsx->autoFilter('A1:B10');
 
@@ -146,7 +158,8 @@ $xlsx->autoFilter('A1:B10');
 $xlsx->freezePanes('C3');
 
 // RTL mode
-// Column A is on the far right, Column B is one column left of Column A, and so on. Also, information in cells is displayed in the Right to Left format.
+// Column A is on the far right, Column B is one column left of Column A, and so on.
+// Also, information in cells is displayed in the Right to Left format.
 $xlsx->rightToLeft();
 
 // Set Meta Data Files


### PR DESCRIPTION
Minor changes:

1. Method with no interaction with object properties/methods, converted to static method: num2name (used in _sheetToXML).
2. Constructor: It's not necessary to initialize the $sheets property since, in the addSheet method, the index 0 of $sheets is overwritten ($curSheet initialized at -1 and becomes 0 when addSheet is called).
3. Minor XML formatting changed (newlines and light indentation): in $template definition (constructor), $SHEETVIEWS, $ROWS, $COLS, $AUTOFILTER, $HYPERLINKS (_sheetToXML), etc.
4. addSheet method: $rows initialization changed to support associative arrays. In the original addSheet method, it is checked if $row is a 2-dimensional array but considering $row as a classic array (2-dimensional array with consecutive numeric indices). But traversing data from the array (in the _sheetToXML method) is done with foreach, which allows the use of arbitrary indexes. So, I think a more correct way to check $row presence is to use:
```php
if (is_array($rows) && is_array($rows[array_key_first($rows)]))
```
but it needs PHP 7.3 so we can use:
```php
if (is_array($rows)) {
	foreach ($rows as $row) {
		if (is_array($row)) $this->sheets[$this->curSheet]['rows'] = $rows;
		break;
	}
}
```
5. saveAs and downloadAs methods: change filename correction to a more aggressive aproach so can be saved in *nix/Win filesystems. Both methods return false on failure or used filename on success.
6. _write method: search & replace sentences changed to one multi-line sentence (I think it gives better readability).
7. Changed coord2cell/cell2coord methods to use array for sheet coordinates. This caused a change in the _sheetToXML method where these methods are used to calculate frozen cells.
8. Method _sheetToXML: added empty element at the end of the arrays $ROWS, $COLS, $MERGECELLS, $HYPERLINKS (like it was originally with $MERGECELLS) and deleted the new lines in the sheet template.
9. The documented methods (and class), converted to PHPDoc format.
10. date2excel method: $century vriable used to calculate $decade to avoid repeating calculation.

I have removed the code related to comments in cells to make it easier to see the changes. In a later version, I will add comment support.
Also, and for the same reason, I did not change the order of the methods but it would be nice to group the static methods, the setters and the rest.
