### PR TITLE
Add column letter support to setColWidth (#171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 1.5.16 (2026-04-22)
+* setColWidth accepts column letters and ranges, e.g. setColWidth('A', 35) or setColWidth('A:C', 15), [#171](https://github.com/shuchkin/simplexlsxgen/issues/171)
+
 # 1.5.15 (2026-03-12)
 * fixed formatted numbers, thx [Roland](https://github.com/mrextreme) [#174](https://github.com/shuchkin/simplexlsxgen/issues/174#issuecomment-4045694443)
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ $data = [
 SimpleXLSXGen::fromArray($data)
     ->setDefaultFont('Courier New')
     ->setDefaultFontSize(14)
-    ->setColWidth(1, 35)
+    ->setColWidth(1, 35)      // or ->setColWidth('A', 35)
+    ->setColWidth('B:C', 20)  // column letters and ranges also work
     ->mergeCells('A20:B20')
     ->saveAs('styles_and_tags.xlsx');
 ```

--- a/src/SimpleXLSXGen.php
+++ b/src/SimpleXLSXGen.php
@@ -1231,13 +1231,22 @@ class SimpleXLSXGen
     }
 
     /**
-     * @param $col int Column index starts with 1
+     * @param $col int|string Column index starts with 1, or column letter ('A', 'AA'), or range ('A:C')
      * @param $width int Width in chars
      * @return $this
      */
     public function setColWidth($col, $width)
     {
-        $this->sheets[$this->curSheet]['colwidth'][$col] = $width;
+        if (is_string($col) && strpos($col, ':') !== false) {
+            list($from, $to) = explode(':', $col, 2);
+            $from = self::col2index($from);
+            $to = self::col2index($to);
+            for ($i = $from; $i <= $to; $i++) {
+                $this->sheets[$this->curSheet]['colwidth'][$i] = $width;
+            }
+            return $this;
+        }
+        $this->sheets[$this->curSheet]['colwidth'][self::col2index($col)] = $width;
         return $this;
     }
     public function rightToLeft($value = true)
@@ -1319,6 +1328,26 @@ class SimpleXLSXGen
             }
         }
         return $array;
+    }
+
+    private static function col2index($col)
+    {
+        if (is_int($col)) {
+            return $col;
+        }
+        $m = null;
+        if (preg_match('/^([A-Za-z]+)$/', $col, $m)) {
+            $letters = strtoupper($m[1]);
+            $len = strlen($letters);
+            $x = 0;
+            for ($i = 0; $i < $len; $i++) {
+                $int = ord($letters[$i]) - 65; // A -> 0, B -> 1
+                $int += ($i === $len - 1) ? 0 : 1;
+                $x += $int * pow(26, $len-$i-1);
+            }
+            return $x + 1;
+        }
+        return (int)$col;
     }
 
     public static function cell2coord($cell, &$x, &$y)


### PR DESCRIPTION
Resolves #171.

`setColWidth` now accepts column letters and ranges in addition to the existing 1-based numeric index. Existing numeric calls behave exactly as before.

```php
$xlsx->setColWidth(1, 35);        // numeric (unchanged)
$xlsx->setColWidth('A', 35);      // column letter
$xlsx->setColWidth('AA', 20);     // multi-letter
$xlsx->setColWidth('A:C', 15);    // range
```

### How it works

A small private static helper `col2index` converts a letter or int to a 1-based column index, reusing the same letter-parsing loop already present in `cell2coord`. `setColWidth` normalizes its first argument through this helper, and the range form is handled with a quick `strpos(':')` check before the single-column path.

### Verified

Generated a workbook with all four call forms and inspected `xl/worksheets/sheet1.xml`:

```
<col min="1" max="1" width="35" customWidth="1" />
<col min="2" max="2" width="22" customWidth="1" />
<col min="3" max="3" width="15" customWidth="1" />
<col min="4" max="4" width="15" customWidth="1" />
<col min="5" max="5" width="15" customWidth="1" />
<col min="27" max="27" width="20" customWidth="1" />
```

### Notes

- No new files, no dependency changes, no namespace changes.
- Public API unchanged; backward compatible for numeric input.
- README example extended, CHANGELOG bumped to 1.5.16.